### PR TITLE
Refactor console menu in io_complex_numbers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,4 +4,5 @@ project(Complex_numbers)
 set(CMAKE_CXX_STANDARD 23)
 
 add_executable(Complex_numbers main.cpp
-        basic_operations.cpp)
+        basic_operations.cpp
+        io_complex_numbers.cpp)

--- a/io_complex_numbers.cpp
+++ b/io_complex_numbers.cpp
@@ -1,44 +1,60 @@
 #include "io_complex_numbers.h"
-#include "basic_operations.h"
+
+#include <iostream>
 
 BasicOperations::Complex x(-4,0);
 BasicOperations::Complex y(-2,1);
 
-int IOComplexNumbers::menu() {
+int IOComplex::get_user_menu_action() {
+    std::cout << std::endl;
+    show_menu();
     int answer;
-    std::cout << "\n1 - Сложить\n"
-         << "2 - Вычесть\n"
-         << "3 - Умножить\n"
-         << "4 - Разделить\n"
-         << "0 - Выход из программы\n"
-         << "> ";
     std::cin >> answer;
     std::cout << std::endl;
     return answer;
 }
 
-void IOComplexNumbers::main_console() {
-    std::cout << "x:    "<< x.Normal_form() << std::endl;
-    std::cout << "y:    "<< y.Normal_form() << std::endl;
-    int ans;
-    while(ans != 0) {
-        ans = menu();
-        switch (ans) {
+void IOComplex::print_example_result(
+    const char* const comment,
+    const BasicOperations::Complex& result
+) {
+    const char format[] = " = ";
+    std::cout << comment << format << result.Normal_form() << std::endl;
+}
+
+void IOComplex::process_menu_action() {
+    print_example_result("x", x);
+    print_example_result("y", y);
+
+    int answer;
+    do {
+        answer = get_user_menu_action();
+        switch (answer) {
             case 0:
                 break;
             case 1:
-                std::cout << "x+y:  " << (x + y).Normal_form() << std::endl;
+                print_example_result("x + y", x + y);
                 break;
             case 2:
-                std::cout << "x-y:  " << (x - y).Normal_form() << std::endl;
+                print_example_result("x - y", x - y);
                 break;
             case 3:
-                std::cout << "x*y:  " << (x * y).Normal_form() << std::endl;
+                print_example_result("x * y", x * y);
                 break;
             case 4:
-                std::cout << "x/y:  " << (x / y).Normal_form() << std::endl;
+                print_example_result("x / y", x / y);
                 break;
-
+            default:
+                break;
         }
-    }
+    } while(answer != 0);
+}
+
+void IOComplex::show_menu() {
+    std::wcout << L"1 - Сложить\n"
+               << L"2 - Вычесть\n"
+               << L"3 - Умножить\n"
+               << L"4 - Разделить\n"
+               << L"0 - Выход из программы\n"
+               << L"> ";
 }

--- a/io_complex_numbers.h
+++ b/io_complex_numbers.h
@@ -1,8 +1,13 @@
 #pragma once
 
-#include <iostream>
+#include "basic_operations.h"
 
-namespace IOComplexNumbers {
-    int menu();
-    void main_console();
+namespace IOComplex {
+    int get_user_menu_action();
+    void print_example_result(
+        const char* const comment,
+        const BasicOperations::Complex& result
+    );
+    void process_menu_action();
+    void show_menu();
 }

--- a/main.cpp
+++ b/main.cpp
@@ -3,7 +3,7 @@
 
 int main() {
     setlocale(LC_ALL, "Russian");
-    IOComplexNumbers::main_console();
+    IOComplex::process_menu_action();
 //    std::cout << "x:    "<< x.Normal_form() << std::endl;     // WORKS
 //    std::cout << "x_theta :    "<< x.GetTheta() << std::endl;     // WORKS
 //    std::cout << "x_angle :    "<< x.GetAngle() << std::endl;     // WORKS


### PR DESCRIPTION
Сделал рефакторинг pull request-а Степана "create console #18", в котором он реализовал консольное меню по вычислению примеров с комплексными числами:
1. Переименовано namespace
2. Даны новые имена функциям
3. Разбиты существующие функции
4. Вынесен повторяющийся код в отдельную функцию
5. Изменено положение #include-ов
6. io_complex_numbers.cpp добавлен в CMakeLists
7. Исправлена ошибка первого вывода меню: while -> do-while
8. В конце файлов добавлена пустая строка, т.к. git из-за её отсутствия не видит символа  конца файла (красный кружочек с минусом)